### PR TITLE
Add missing header file for memset

### DIFF
--- a/zed-unity-livelink-fusion/src/PracticalSocket.cpp
+++ b/zed-unity-livelink-fusion/src/PracticalSocket.cpp
@@ -34,6 +34,7 @@ typedef void raw_type;       // Type used for raw data on this platform
 #endif
 
 #include <errno.h>             // For errno
+#include <cstring>             // For memset
 
 #pragma comment(lib, "Ws2_32.lib")
 


### PR DESCRIPTION
### PR Title:
Fix: Include cstring header for memset

### PR Description:
'memset' function is being called without the 'cstring' header file in PracticalSocket.cpp
The build error is as follows:
```
zed-unity-livelink/zed-unity-livelink-fusion/src/PracticalSocket.cpp:311:5: error: ‘memset’ was not declared in this scope
  311 |     memset(&nullAddr, 0, sizeof(nullAddr));
```

### Solution:
Include cstring header in PracticalSocket.cpp

### Testing
I tested it in ubuntu 20.04

When I have locally tested changes by compiling with the 'cstring' header file included,
The program now compiles without error.
![Screenshot from 2023-05-12 14-16-49](https://github.com/stereolabs/zed-unity-livelink/assets/60388186/4612b893-1130-4f9b-aa8d-58663150d2fd)